### PR TITLE
Captive portal support.

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -104,6 +104,10 @@ bool Basecamp::begin() {
 
 	String infotext2 = "This device has the MAC-Address: " + mac;
 	web.addInterfaceElement("infotext2", "p", infotext2,"#wrapper");
+
+	if(configuration.get("WifiConfigured") != "True"){
+    dnsServer.start(53, "*", wifi.getSoftAPIP());
+	}
 #endif
 
 	Serial.println(showSystemInfo());

--- a/Basecamp.hpp
+++ b/Basecamp.hpp
@@ -16,6 +16,7 @@
 #endif
 
 #ifndef BASECAMP_NOWEB
+#include <DNSServer.h>
 #include "WebServer.hpp"
 #endif
 
@@ -52,6 +53,7 @@ class Basecamp {
 #endif
 
 #ifndef BASECAMP_NOWEB
+		DNSServer dnsServer;
 		WebServer web;
 #endif
 

--- a/CaptiveRequestHandler.hpp
+++ b/CaptiveRequestHandler.hpp
@@ -1,0 +1,26 @@
+#ifndef CaptiveRequestHandler_h
+#define CaptiveRequestHandler_h
+class CaptiveRequestHandler : public AsyncWebHandler {
+public:
+  CaptiveRequestHandler() {
+  }
+  virtual ~CaptiveRequestHandler() {
+  }
+
+  bool canHandle(AsyncWebServerRequest *request) {
+    //skip all basecamp related sources - handle all other requests and return the default html
+    if (request->url() != "/basecamp.css" && request->url() != "/basecamp.js" && request->url() != "/data.json" && request->url() != "/submitconfig") {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void handleRequest(AsyncWebServerRequest *request) {
+    AsyncWebServerResponse *response = request->beginResponse_P(
+        200, "text/html", index_htm_gz, index_htm_gz_len);
+    response->addHeader("Content-Encoding", "gzip");
+    request->send(response);
+  }
+};
+#endif

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -11,6 +11,7 @@ void WebServer::begin(Configuration &configuration) {
 	SPIFFS.begin();
 	server = new AsyncWebServer(80);
 	events = new AsyncEventSource("/events");
+	server->addHandler(new CaptiveRequestHandler()).setFilter(ON_AP_FILTER);
 	server->addHandler(events);
 	server->begin();
 

--- a/WebServer.hpp
+++ b/WebServer.hpp
@@ -19,6 +19,7 @@
 #include <AsyncJson.h>
 #include <ArduinoJson.h>
 #include "WebInterface.hpp"
+#include "CaptiveRequestHandler.hpp"
 
 class WebServer {
 	public:

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -43,6 +43,9 @@ int WifiControl::status() {
 IPAddress WifiControl::getIP() {
 	return WiFi.localIP();
 }
+IPAddress WifiControl::getSoftAPIP() {
+	return WiFi.softAPIP();
+}
 
 void WifiControl::WiFiEvent(WiFiEvent_t event)
 {

--- a/WifiControl.hpp
+++ b/WifiControl.hpp
@@ -21,6 +21,7 @@ class WifiControl {
 		bool disconnect();
 		void begin(String essid, String password = "", String configured = "False", String hostname = "BasecampDevice");
 		IPAddress getIP();
+		IPAddress getSoftAPIP();
 		int status();
 		static void WiFiEvent(WiFiEvent_t event);
 	private:

--- a/library.json
+++ b/library.json
@@ -16,7 +16,7 @@
             "frameworks": "arduino"
         },
         {
-            "name": "ArduinoJSON",
+            "name": "ArduinoJson",
             "frameworks": "arduino"
         },
         {


### PR DESCRIPTION
Captive portal support, so you don't have to type in 192.168.4.1 in your browser again when you try to setup your device. Tested on OSX and iOS.

![esp32 captive portal osx](https://user-images.githubusercontent.com/6407553/35210323-0a5b2562-ff52-11e7-8e40-718120eb3f24.png)

Ensure to call
`iot.dnsServer.processNextRequest();`
periodically in your loop() block.