### PR TITLE
Wifi AP SSID with mac-address

### DIFF
--- a/Basecamp.hpp
+++ b/Basecamp.hpp
@@ -67,7 +67,5 @@ class Basecamp {
 	private:
 		// TODO: Functionname is misleading
 		String _generateHostname();
-		// TODO: Functionname is misleading
-		String _generateMac();
 };
 #endif

--- a/WifiControl.hpp
+++ b/WifiControl.hpp
@@ -21,10 +21,19 @@ class WifiControl {
 		IPAddress getSoftAPIP();
 		int status();
 		static void WiFiEvent(WiFiEvent_t event);
+
+		/*
+			Returns the MAC Address of the wifi adapter in hexadecimal form, optionally delimited
+			by a given delimiter which is inserted between every hex-representation.
+			e.G. getMacAddress(":") would return "aa:bb:cc:..."
+		*/
+		String getHardwareMacAddress(const String& delimiter = {});
+		String getSoftwareMacAddress(const String& delimiter = {});
 	private:
 		String _wifiEssid;
 		String _wifiPassword;
 		String _ap;
+		String _wifiAPName;
 };
 
 #endif


### PR DESCRIPTION
If the device enter AP mode, its name is now "ESP32_" followed by its mac addres to distinguish multiple not yet setupped devices on the network.