### PR TITLE
Secure wifi ap mode

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -16,7 +16,6 @@ namespace {
 Basecamp::Basecamp()
 	: configuration(String{"/basecamp.json"})
 {
-
 }
 
 /**
@@ -49,7 +48,6 @@ String Basecamp::_generateHostname()
 /**
  * This is the initialisation function for the Basecamp class.
  */
-
 bool Basecamp::begin()
 {
 	// Enable serial output
@@ -61,7 +59,7 @@ bool Basecamp::begin()
 	// If configuration.load() fails, reset the configuration
 	if (!configuration.load()) {
 		DEBUG_PRINTLN("Configuration is broken. Resetting.");
-		configuration.reset();
+		configuration.resetExcept({ConfigurationKey::accessPointSecret, });
 	};
 
 	// Get a cleaned version of the device name.
@@ -228,8 +226,8 @@ void Basecamp::MqttHandling(void *mqttPointer)
 
 #ifdef DNSServer_h
 // This is a task that handles DNS requests from clients
-void Basecamp::DnsHandling(void * dnsServerPointer) {
-
+void Basecamp::DnsHandling(void * dnsServerPointer)
+{
 		DNSServer * dnsServer = (DNSServer *) dnsServerPointer;
 		while(1) {
 			// handle each request
@@ -238,7 +236,6 @@ void Basecamp::DnsHandling(void * dnsServerPointer) {
 		}
 };
 #endif
-
 
 // This function checks the reset reason returned by the ESP and resets the configuration if neccessary.
 // It counts all system reboots that occured by power cycles or button resets.

--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -12,7 +12,7 @@ namespace {
 	const constexpr uint16_t defaultThreadStackSize = 3072;
 	const constexpr UBaseType_t defaultThreadPriority = 0;
 	// Default length for access point mode password
-	const constexpr unsigned defaultApSecretLength = 6;
+	const constexpr unsigned defaultApSecretLength = 8;
 }
 
 Basecamp::Basecamp()

--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -15,8 +15,9 @@ namespace {
 	const constexpr unsigned defaultApSecretLength = 8;
 }
 
-Basecamp::Basecamp()
+Basecamp::Basecamp(SetupModeWifiEncryption setupModeWifiEncryption)
 	: configuration(String{"/basecamp.json"})
+	, setupModeWifiEncryption_(setupModeWifiEncryption)
 {
 }
 
@@ -93,12 +94,12 @@ bool Basecamp::begin()
 			configuration.get("WifiPassword"), // The WiFi password
 			configuration.get("WifiConfigured"), // Has the WiFi been configured
 			hostname, // The system hostname to use for DHCP
-			configuration.get(ConfigurationKey::accessPointSecret)
+			(setupModeWifiEncryption_ == SetupModeWifiEncryption::none)?"":configuration.get(ConfigurationKey::accessPointSecret)
 	);
 
 	// Get WiFI MAC
 	mac = wifi.getSoftwareMacAddress(":");
-	DEBUG_PRINTLN(showSystemInfo().c_str());
+	Serial.println(showSystemInfo().c_str());
 #endif
 #ifndef BASECAMP_NOMQTT
 	// Check if MQTT has been disabled by the user

--- a/Basecamp.hpp
+++ b/Basecamp.hpp
@@ -30,7 +30,14 @@
 
 class Basecamp {
 	public:
-		Basecamp();
+		// How to handle encryption in setup mode (AP mode)
+		enum class SetupModeWifiEncryption
+		{
+			none,			///< Do not use WiFi encryption (open network)
+			secured,	///< Use ESP32 default encryption (WPA2 at this time)
+		};
+
+		Basecamp(Basecamp::SetupModeWifiEncryption setupModeWifiEncryption = Basecamp::SetupModeWifiEncryption::none);
 		~Basecamp() = default;
 		Configuration configuration;
 		Preferences preferences;
@@ -67,5 +74,6 @@ class Basecamp {
 	private:
 		// TODO: Functionname is misleading
 		String _generateHostname();
+		SetupModeWifiEncryption setupModeWifiEncryption_;
 };
 #endif

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -121,6 +121,17 @@ bool Configuration::keyExists(ConfigurationKey key) const
 	return (configuration.find(getKeyName(key)) != configuration.end());
 }
 
+bool Configuration::isKeySet(ConfigurationKey key) const
+{
+	auto found = configuration.find(getKeyName(key));
+	if (found == configuration.end())
+	{
+		return false;
+	}
+
+	return (found->second.length() > 0);
+}
+
 void Configuration::reset()
 {
 	configuration.clear();

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -73,7 +73,6 @@ bool Configuration::save() {
 	return true;
 }
 
-
 void Configuration::set(String key, String value) {
 	std::ostringstream debug;
 	debug << "Settting " << key.c_str() << " to " << value.c_str() << "(was " << get(key).c_str() << ")";
@@ -87,7 +86,13 @@ void Configuration::set(String key, String value) {
 	}
 }
 
-const String &Configuration::get(String key) const {
+void Configuration::set(ConfigurationKey key, String value)
+{
+	set(getKeyName(key), std::move(value));
+}
+
+const String &Configuration::get(String key) const
+{
 	auto found = configuration.find(key);
 	if (found != configuration.end()) {
 		std::ostringstream debug;
@@ -101,8 +106,44 @@ const String &Configuration::get(String key) const {
 	return noResult_;
 }
 
-void Configuration::reset() {
+const String &Configuration::get(ConfigurationKey key) const
+{
+	return get(getKeyName(key));
+}
+
+bool Configuration::keyExists(const String& key) const
+{
+	return (configuration.find(key) != configuration.end());
+}
+
+bool Configuration::keyExists(ConfigurationKey key) const
+{
+	return (configuration.find(getKeyName(key)) != configuration.end());
+}
+
+void Configuration::reset()
+{
 	configuration.clear();
+	this->save();
+	this->load();
+}
+
+void Configuration::resetExcept(const std::list<ConfigurationKey> &keysToPreserve)
+{
+	std::map<ConfigurationKey, String> preservedKeys;
+	for (const auto &key : keysToPreserve) {
+		if (keyExists(key)) {
+			// Make a copy of the old value
+			preservedKeys[key] = get(key);
+		}
+	}
+
+	configuration.clear();
+
+	for (const auto &key : preservedKeys) {
+		set(key.first, key.second);
+	}
+
 	this->save();
 	this->load();
 }

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -51,6 +51,9 @@ class Configuration {
 		// Returns true if the key 'key' exists
 		bool keyExists(ConfigurationKey key) const;
 
+		// Returns true if the key 'key' exists and is not empty
+		bool isKeySet(ConfigurationKey key) const;
+
 		// Reset the whole configuration
 		void reset();
 

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -8,6 +8,7 @@
 #define Configuration_h
 
 #include <sstream>
+#include <list>
 #include <map>
 
 #include <ArduinoJson.h>
@@ -15,18 +16,58 @@
 #include <SPIFFS.h>
 #include "debug.hpp"
 
+// TODO: Extend with all known keys
+enum class ConfigurationKey {
+	accessPointSecret,
+};
+
+// TODO: Extend with all known keys
+static const String getKeyName(ConfigurationKey key)
+{
+	// This automatically will break the compiler if a known key has been forgotten
+	// (if the warnings are turned on exactly...)
+	switch (key)
+	{
+		case ConfigurationKey::accessPointSecret:
+			return "APSecret";
+			break;
+	}
+}
+
 class Configuration {
 	public:
 		explicit Configuration(String filename);
 		~Configuration() = default;
 
+		const String& getKey(ConfigurationKey configKey) const;
+
 		bool load();
 		bool save();
 		void dump();
+
+		// Returns true if the key 'key' exists
+		bool keyExists(const String& key) const;
+
+		// Returns true if the key 'key' exists
+		bool keyExists(ConfigurationKey key) const;
+
+		// Reset the whole configuration
 		void reset();
 
+		// Reset everything except the AP secret
+		void resetExcept(const std::list<ConfigurationKey> &keysToPreserve);
+
+		// FIXME: Get rid of every direct access ("name") set() and get()
+		// to minimize the rist of unknown-key usage. Move to private.
 		void set(String key, String value);
+		// FIXME: use this instead
+		void set(ConfigurationKey key, String value);
+
+		// FIXME: Get rid of every direct access ("name") set() and get()
+		// to minimize the rist of unknown-key usage. Move to private.
 		const String& get(String key) const;
+		// FIXME: use this instead
+		const String& get(ConfigurationKey key) const;
 
 		struct cmp_str
 		{

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This library has few dependencies:
 
 Exhaustive documentation will provided in the next few weeks. An example can be found inside the example folder.
 
+### First Setup:
+At the first start - when you initially flash the device, the ESP32 will generate an
+unique password which is displayed at the debug console upon every start. In setup mode (when the ESP32 is acting as
+	an access point for setup), the password for the "ESP_$macOfEsp32" wifi network will be set to this value. It will never change,
+	except the configuration gets broken - then a new password will be generated.
+
 ## Basic example
 
 ```cpp
@@ -31,11 +37,11 @@ void setup() {
 	iot.begin();
     //The mqtt object is an instance of Async MQTT Client. See it's documentation for details.
     iot.mqtt.subscribe("test/lol",2);
-    
+
     //Use the web object to add elements to the interface
     iot.web.addInterfaceElement("color", "input", "", "#configform", "LampColor");
     iot.web.setInterfaceElementAttribute("color", "type", "text");
-    
+
 }
 
 void loop() {

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -10,7 +10,13 @@
 #include "debug.hpp"
 #include "Basecamp.hpp"
 
-void WifiControl::begin(String essid, String password, String configured, String hostname)
+namespace {
+	// Minumum access point secret length to be generated (8 is min for ESP32)
+	const constexpr unsigned minApSecretLength = 8;
+}
+
+void WifiControl::begin(String essid, String password, String configured,
+												String hostname, String apSecret)
 {
 	DEBUG_PRINTLN("Connecting to Wifi");
 
@@ -35,7 +41,14 @@ void WifiControl::begin(String essid, String password, String configured, String
 		DEBUG_PRINTF("Starting Wifi AP '%s'", _wifiAPName);
 
 		WiFi.mode(WIFI_AP_STA);
-		WiFi.softAP(_wifiAPName.c_str());
+		if (apSecret.length() > 0) {
+			// Start with password protection
+			Serial.printf("Starting AP with password %s\n", apSecret.c_str());
+			WiFi.softAP(_wifiAPName.c_str(), apSecret.c_str());
+		} else {
+			// Start without password protection
+			WiFi.softAP(_wifiAPName.c_str());
+		}
 	}
 }
 
@@ -105,4 +118,21 @@ String WifiControl::getSoftwareMacAddress(const String& delimiter)
 	uint8_t rawMac[6];
 	WiFi.macAddress(rawMac);
 	return format6Bytes(rawMac, delimiter);
+}
+
+String WifiControl::generateRandomSecret(unsigned length) const
+{
+	// There is no "O" (Oh) to reduce confusion
+	const String validChars{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789.-,:!$/"};
+	String returnValue;
+	returnValue.reserve(length);
+
+	unsigned useLength = (length < minApSecretLength)?minApSecretLength:length;
+	for (unsigned i = 0; i < useLength; i++)
+	{
+		auto randomValue = validChars[(esp_random() % validChars.length())];
+		returnValue += randomValue;
+	}
+
+	return returnValue;
 }

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -123,7 +123,7 @@ String WifiControl::getSoftwareMacAddress(const String& delimiter)
 String WifiControl::generateRandomSecret(unsigned length) const
 {
 	// There is no "O" (Oh) to reduce confusion
-	const String validChars{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789.-,:!$/"};
+	const String validChars{"abcdefghjkmnopqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ23456789.-,:$/"};
 	String returnValue;
 
 	unsigned useLength = (length < minApSecretLength)?minApSecretLength:length;

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -125,9 +125,10 @@ String WifiControl::generateRandomSecret(unsigned length) const
 	// There is no "O" (Oh) to reduce confusion
 	const String validChars{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789.-,:!$/"};
 	String returnValue;
-	returnValue.reserve(length);
 
 	unsigned useLength = (length < minApSecretLength)?minApSecretLength:length;
+	returnValue.reserve(useLength);
+
 	for (unsigned i = 0; i < useLength; i++)
 	{
 		auto randomValue = validChars[(esp_random() % validChars.length())];

--- a/WifiControl.hpp
+++ b/WifiControl.hpp
@@ -16,11 +16,15 @@ class WifiControl {
 		WifiControl(){};
 		bool connect();
 		bool disconnect();
-		void begin(String essid, String password = "", String configured = "False", String hostname = "BasecampDevice");
+
+		void begin(String essid, String password = "", String configured = "False",
+							 String hostname = "BasecampDevice", String apSecret="");
 		IPAddress getIP();
 		IPAddress getSoftAPIP();
 		int status();
 		static void WiFiEvent(WiFiEvent_t event);
+
+		String generateRandomSecret(unsigned length) const;
 
 		/*
 			Returns the MAC Address of the wifi adapter in hexadecimal form, optionally delimited

--- a/examples/doorsensor/doorsensor.ino
+++ b/examples/doorsensor/doorsensor.ino
@@ -5,8 +5,11 @@
 #include <Basecamp.hpp>
 #include <Configuration.hpp>
 
-//Create a new Basecamp instance called iot
-Basecamp iot;
+// Create a new Basecamp instance called iot
+// Uncomment the following line to start the ESP with secured WiFi-AP on first start
+Basecamp iot{Basecamp::SetupModeWifiEncryption::secured};
+// ..or run it in default mode with open wifi-ap network
+// Basecamp iot;
 
 //Variables for the sensor and the battery
 static const int ResetPin = 35;

--- a/examples/doorsensor/doorsensor.ino
+++ b/examples/doorsensor/doorsensor.ino
@@ -32,7 +32,7 @@ void resetToFactoryDefaults()
     DEBUG_PRINTLN("Resetting to factory defaults");
     Configuration config(String{"/basecamp.json"});
     config.load();
-    config.reset();
+    config.resetExcept({ConfigurationKey::accessPointSecret, });
     config.save();  
 }
 

--- a/examples/doorsensor/doorsensor.ino
+++ b/examples/doorsensor/doorsensor.ino
@@ -33,7 +33,7 @@ void resetToFactoryDefaults()
     Configuration config(String{"/basecamp.json"});
     config.load();
     config.resetExcept({ConfigurationKey::accessPointSecret, });
-    config.save();  
+    config.save();
 }
 
 void setup() {
@@ -75,7 +75,7 @@ void setup() {
 //This function is called when the MQTT-Server is connected
 void onMqttConnect(bool sessionPresent) {
   DEBUG_PRINTLN(__func__);
-  
+
   //Subscribe to the delay topic
   iot.mqtt.subscribe(delaySleepTopic.c_str(), 0);
   //Trigger the transmission of the current state.
@@ -135,10 +135,10 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
 
 void suspendESP(uint16_t packetId) {
   DEBUG_PRINTLN(__func__);
-  
+
   //Check if the published package is the one of the door sensor
   if (packetId == statusPacketIdSub) {
-   
+
     if (delaySleep == true) {
       DEBUG_PRINTLN("Delaying Sleep");
       return;
@@ -151,6 +151,6 @@ void suspendESP(uint16_t packetId) {
   }
 }
 
-void loop() 
+void loop()
 {
 }


### PR DESCRIPTION
In setup-mode, the ESP32 acts as an access point.
Until this PR, this was an open network.
Means: everybody could just read the setup webpage-submit to the esp including mqtt and main wifi network password.

Now, upon first flash / run, an unique password is generated and the ESP32 access point will start in WPA2-Mode with this password being set.

The ESP32 will show this password within the showSystemInfo() on the serial console.
As the esp has to be flashed at least once, this should be sufficient to note the password.

The password should survive the DoorSensor-Sample reset-Pin so the password could be just noted for that esp-mac for once and ever. One exception: if the config is reset because a broken config is detected, a new password will be generated as well.

-- As a side note: I changed the get/set functions to use enums instead of direct key-names.
