### PR TITLE
Start servers only in setup mode

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -149,57 +149,61 @@ bool Basecamp::begin()
 #endif
 
 #ifndef BASECAMP_NOWEB
-	// Start webserver and pass the configuration object to it
-	web.begin(configuration);
+	// Starting the webserver only makes sense in setup mode. In productive mode,
+	// the device will enter deep sleep so the server will not work at all.
+	if (wifi.getOperationMode() == WifiControl::Mode::accessPoint)
+	{
+		// Start webserver and pass the configuration object to it
+		web.begin(configuration);
 
-	// Add a webinterface element for the h1 that contains the device name. It is a child of the #wrapper-element.
-	web.addInterfaceElement("heading", "h1", configuration.get("DeviceName"),"#wrapper");
-	// Set the class attribute of the element to fat-border.
-	web.setInterfaceElementAttribute("heading", "class", "fat-border");
+		// Add a webinterface element for the h1 that contains the device name. It is a child of the #wrapper-element.
+		web.addInterfaceElement("heading", "h1", configuration.get("DeviceName"),"#wrapper");
+		// Set the class attribute of the element to fat-border.
+		web.setInterfaceElementAttribute("heading", "class", "fat-border");
 
-	// Add a paragraph with some basic information
-	web.addInterfaceElement("infotext1", "p", "Configure your device with the following options:","#wrapper");
+		// Add a paragraph with some basic information
+		web.addInterfaceElement("infotext1", "p", "Configure your device with the following options:","#wrapper");
 
-	// Add the configuration form, that will include all inputs for config data
-	web.addInterfaceElement("configform", "form", "","#wrapper");
-	web.setInterfaceElementAttribute("configform", "action", "saveConfig");
+		// Add the configuration form, that will include all inputs for config data
+		web.addInterfaceElement("configform", "form", "","#wrapper");
+		web.setInterfaceElementAttribute("configform", "action", "saveConfig");
 
-	web.addInterfaceElement("DeviceName", "input", "Device name","#configform" , "DeviceName");
+		web.addInterfaceElement("DeviceName", "input", "Device name","#configform" , "DeviceName");
 
-	// Add an input field for the WIFI data and link it to the corresponding configuration data
-	web.addInterfaceElement("WifiEssid", "input", "WIFI SSID:","#configform" , "WifiEssid");
-	web.addInterfaceElement("WifiPassword", "input", "WIFI Password:", "#configform", "WifiPassword");
-	web.setInterfaceElementAttribute("WifiPassword", "type", "password");
-	web.addInterfaceElement("WifiConfigured", "input", "", "#configform", "WifiConfigured");
-	web.setInterfaceElementAttribute("WifiConfigured", "type", "hidden");
-	web.setInterfaceElementAttribute("WifiConfigured", "value", "true");
+		// Add an input field for the WIFI data and link it to the corresponding configuration data
+		web.addInterfaceElement("WifiEssid", "input", "WIFI SSID:","#configform" , "WifiEssid");
+		web.addInterfaceElement("WifiPassword", "input", "WIFI Password:", "#configform", "WifiPassword");
+		web.setInterfaceElementAttribute("WifiPassword", "type", "password");
+		web.addInterfaceElement("WifiConfigured", "input", "", "#configform", "WifiConfigured");
+		web.setInterfaceElementAttribute("WifiConfigured", "type", "hidden");
+		web.setInterfaceElementAttribute("WifiConfigured", "value", "true");
 
-	// Add input fields for MQTT configurations if it hasn't been disabled
-	if (configuration.get("MQTTActive") != "false") {
-		web.addInterfaceElement("MQTTHost", "input", "MQTT Host:","#configform" , "MQTTHost");
-		web.addInterfaceElement("MQTTPort", "input", "MQTT Port:","#configform" , "MQTTPort");
-		web.setInterfaceElementAttribute("MQTTPort", "type", "number");
-		web.addInterfaceElement("MQTTUser", "input", "MQTT Username:","#configform" , "MQTTUser");
-		web.addInterfaceElement("MQTTPass", "input", "MQTT Password:","#configform" , "MQTTPass");
-		web.setInterfaceElementAttribute("MQTTPass", "type", "password");
-	}
-	// Add a save button that calls the JavaScript function collectConfiguration() on click
-	web.addInterfaceElement("saveform", "input", " ","#configform");
-	web.setInterfaceElementAttribute("saveform", "type", "button");
-	web.setInterfaceElementAttribute("saveform", "value", "Save");
-	web.setInterfaceElementAttribute("saveform", "onclick", "collectConfiguration()");
+		// Add input fields for MQTT configurations if it hasn't been disabled
+		if (configuration.get("MQTTActive") != "false") {
+			web.addInterfaceElement("MQTTHost", "input", "MQTT Host:","#configform" , "MQTTHost");
+			web.addInterfaceElement("MQTTPort", "input", "MQTT Port:","#configform" , "MQTTPort");
+			web.setInterfaceElementAttribute("MQTTPort", "type", "number");
+			web.addInterfaceElement("MQTTUser", "input", "MQTT Username:","#configform" , "MQTTUser");
+			web.addInterfaceElement("MQTTPass", "input", "MQTT Password:","#configform" , "MQTTPass");
+			web.setInterfaceElementAttribute("MQTTPass", "type", "password");
+		}
+		// Add a save button that calls the JavaScript function collectConfiguration() on click
+		web.addInterfaceElement("saveform", "input", " ","#configform");
+		web.setInterfaceElementAttribute("saveform", "type", "button");
+		web.setInterfaceElementAttribute("saveform", "value", "Save");
+		web.setInterfaceElementAttribute("saveform", "onclick", "collectConfiguration()");
 
-	// Show the devices MAC in the Webinterface
-	String infotext2 = "This device has the MAC-Address: " + mac;
-	web.addInterfaceElement("infotext2", "p", infotext2,"#wrapper");
-#ifdef DNSServer_h
-	if(configuration.get("WifiConfigured") != "True"){
-    		dnsServer.start(53, "*", wifi.getSoftAPIP());
-		xTaskCreatePinnedToCore(&DnsHandling, "DNSTask", 4096, (void*) &dnsServer, 5, NULL,0);
+		// Show the devices MAC in the Webinterface
+		String infotext2 = "This device has the MAC-Address: " + mac;
+		web.addInterfaceElement("infotext2", "p", infotext2,"#wrapper");
+		#ifdef DNSServer_h
+		if(configuration.get("WifiConfigured") != "True"){
+			dnsServer.start(53, "*", wifi.getSoftAPIP());
+			xTaskCreatePinnedToCore(&DnsHandling, "DNSTask", 4096, (void*) &dnsServer, 5, NULL,0);
+		}
+		#endif
 	}
 	#endif
-#endif
-
 	Serial.println(showSystemInfo());
 
 	// TODO: only return true if everything setup up correctly

--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -16,7 +16,6 @@ namespace {
 Basecamp::Basecamp()
 	: configuration(String{"/basecamp.json"})
 {
-
 }
 
 /**
@@ -49,7 +48,6 @@ String Basecamp::_generateHostname()
 /**
  * This is the initialisation function for the Basecamp class.
  */
-
 bool Basecamp::begin()
 {
 	// Enable serial output
@@ -61,7 +59,7 @@ bool Basecamp::begin()
 	// If configuration.load() fails, reset the configuration
 	if (!configuration.load()) {
 		DEBUG_PRINTLN("Configuration is broken. Resetting.");
-		configuration.reset();
+		configuration.resetExcept({ConfigurationKey::accessPointSecret, });
 	};
 
 	// Get a cleaned version of the device name.
@@ -228,8 +226,8 @@ void Basecamp::MqttHandling(void *mqttPointer)
 
 #ifdef DNSServer_h
 // This is a task that handles DNS requests from clients
-void Basecamp::DnsHandling(void * dnsServerPointer) {
-
+void Basecamp::DnsHandling(void * dnsServerPointer)
+{
 		DNSServer * dnsServer = (DNSServer *) dnsServerPointer;
 		while(1) {
 			// handle each request
@@ -238,7 +236,6 @@ void Basecamp::DnsHandling(void * dnsServerPointer) {
 		}
 };
 #endif
-
 
 // This function checks the reset reason returned by the ESP and resets the configuration if neccessary.
 // It counts all system reboots that occured by power cycles or button resets.

--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -12,7 +12,7 @@ namespace {
 	const constexpr uint16_t defaultThreadStackSize = 3072;
 	const constexpr UBaseType_t defaultThreadPriority = 0;
 	// Default length for access point mode password
-	const constexpr unsigned defaultApSecretLength = 6;
+	const constexpr unsigned defaultApSecretLength = 8;
 }
 
 Basecamp::Basecamp()

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -121,6 +121,17 @@ bool Configuration::keyExists(ConfigurationKey key) const
 	return (configuration.find(getKeyName(key)) != configuration.end());
 }
 
+bool Configuration::isKeySet(ConfigurationKey key) const
+{
+	auto found = configuration.find(getKeyName(key));
+	if (found == configuration.end())
+	{
+		return false;
+	}
+
+	return (found->second.length() > 0);
+}
+
 void Configuration::reset()
 {
 	configuration.clear();

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -73,7 +73,6 @@ bool Configuration::save() {
 	return true;
 }
 
-
 void Configuration::set(String key, String value) {
 	std::ostringstream debug;
 	debug << "Settting " << key.c_str() << " to " << value.c_str() << "(was " << get(key).c_str() << ")";
@@ -87,7 +86,13 @@ void Configuration::set(String key, String value) {
 	}
 }
 
-const String &Configuration::get(String key) const {
+void Configuration::set(ConfigurationKey key, String value)
+{
+	set(getKeyName(key), std::move(value));
+}
+
+const String &Configuration::get(String key) const
+{
 	auto found = configuration.find(key);
 	if (found != configuration.end()) {
 		std::ostringstream debug;
@@ -101,8 +106,44 @@ const String &Configuration::get(String key) const {
 	return noResult_;
 }
 
-void Configuration::reset() {
+const String &Configuration::get(ConfigurationKey key) const
+{
+	return get(getKeyName(key));
+}
+
+bool Configuration::keyExists(const String& key) const
+{
+	return (configuration.find(key) != configuration.end());
+}
+
+bool Configuration::keyExists(ConfigurationKey key) const
+{
+	return (configuration.find(getKeyName(key)) != configuration.end());
+}
+
+void Configuration::reset()
+{
 	configuration.clear();
+	this->save();
+	this->load();
+}
+
+void Configuration::resetExcept(const std::list<ConfigurationKey> &keysToPreserve)
+{
+	std::map<ConfigurationKey, String> preservedKeys;
+	for (const auto &key : keysToPreserve) {
+		if (keyExists(key)) {
+			// Make a copy of the old value
+			preservedKeys[key] = get(key);
+		}
+	}
+
+	configuration.clear();
+
+	for (const auto &key : preservedKeys) {
+		set(key.first, key.second);
+	}
+
 	this->save();
 	this->load();
 }

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -51,6 +51,9 @@ class Configuration {
 		// Returns true if the key 'key' exists
 		bool keyExists(ConfigurationKey key) const;
 
+		// Returns true if the key 'key' exists and is not empty
+		bool isKeySet(ConfigurationKey key) const;
+
 		// Reset the whole configuration
 		void reset();
 

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -8,6 +8,7 @@
 #define Configuration_h
 
 #include <sstream>
+#include <list>
 #include <map>
 
 #include <ArduinoJson.h>
@@ -15,18 +16,58 @@
 #include <SPIFFS.h>
 #include "debug.hpp"
 
+// TODO: Extend with all known keys
+enum class ConfigurationKey {
+	accessPointSecret,
+};
+
+// TODO: Extend with all known keys
+static const String getKeyName(ConfigurationKey key)
+{
+	// This automatically will break the compiler if a known key has been forgotten
+	// (if the warnings are turned on exactly...)
+	switch (key)
+	{
+		case ConfigurationKey::accessPointSecret:
+			return "APSecret";
+			break;
+	}
+}
+
 class Configuration {
 	public:
 		explicit Configuration(String filename);
 		~Configuration() = default;
 
+		const String& getKey(ConfigurationKey configKey) const;
+
 		bool load();
 		bool save();
 		void dump();
+
+		// Returns true if the key 'key' exists
+		bool keyExists(const String& key) const;
+
+		// Returns true if the key 'key' exists
+		bool keyExists(ConfigurationKey key) const;
+
+		// Reset the whole configuration
 		void reset();
 
+		// Reset everything except the AP secret
+		void resetExcept(const std::list<ConfigurationKey> &keysToPreserve);
+
+		// FIXME: Get rid of every direct access ("name") set() and get()
+		// to minimize the rist of unknown-key usage. Move to private.
 		void set(String key, String value);
+		// FIXME: use this instead
+		void set(ConfigurationKey key, String value);
+
+		// FIXME: Get rid of every direct access ("name") set() and get()
+		// to minimize the rist of unknown-key usage. Move to private.
 		const String& get(String key) const;
+		// FIXME: use this instead
+		const String& get(ConfigurationKey key) const;
 
 		struct cmp_str
 		{

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This library has few dependencies:
 
 Exhaustive documentation will provided in the next few weeks. An example can be found inside the example folder.
 
+### First Setup:
+At the first start - when you initially flash the device, the ESP32 will generate an
+unique password which is displayed at the debug console upon every start. In setup mode (when the ESP32 is acting as
+	an access point for setup), the password for the "ESP_$macOfEsp32" wifi network will be set to this value. It will never change,
+	except the configuration gets broken - then a new password will be generated.
+
 ## Basic example
 
 ```cpp
@@ -31,11 +37,11 @@ void setup() {
 	iot.begin();
     //The mqtt object is an instance of Async MQTT Client. See it's documentation for details.
     iot.mqtt.subscribe("test/lol",2);
-    
+
     //Use the web object to add elements to the interface
     iot.web.addInterfaceElement("color", "input", "", "#configform", "LampColor");
     iot.web.setInterfaceElementAttribute("color", "type", "text");
-    
+
 }
 
 void loop() {

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -10,7 +10,13 @@
 #include "debug.hpp"
 #include "Basecamp.hpp"
 
-void WifiControl::begin(String essid, String password, String configured, String hostname)
+namespace {
+	// Minumum access point secret length to be generated (8 is min for ESP32)
+	const constexpr unsigned minApSecretLength = 8;
+}
+
+void WifiControl::begin(String essid, String password, String configured,
+												String hostname, String apSecret)
 {
 	DEBUG_PRINTLN("Connecting to Wifi");
 
@@ -35,7 +41,14 @@ void WifiControl::begin(String essid, String password, String configured, String
 		DEBUG_PRINTF("Starting Wifi AP '%s'", _wifiAPName);
 
 		WiFi.mode(WIFI_AP_STA);
-		WiFi.softAP(_wifiAPName.c_str());
+		if (apSecret.length() > 0) {
+			// Start with password protection
+			Serial.printf("Starting AP with password %s\n", apSecret.c_str());
+			WiFi.softAP(_wifiAPName.c_str(), apSecret.c_str());
+		} else {
+			// Start without password protection
+			WiFi.softAP(_wifiAPName.c_str());
+		}
 	}
 }
 
@@ -105,4 +118,21 @@ String WifiControl::getSoftwareMacAddress(const String& delimiter)
 	uint8_t rawMac[6];
 	WiFi.macAddress(rawMac);
 	return format6Bytes(rawMac, delimiter);
+}
+
+String WifiControl::generateRandomSecret(unsigned length) const
+{
+	// There is no "O" (Oh) to reduce confusion
+	const String validChars{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789.-,:!$/"};
+	String returnValue;
+	returnValue.reserve(length);
+
+	unsigned useLength = (length < minApSecretLength)?minApSecretLength:length;
+	for (unsigned i = 0; i < useLength; i++)
+	{
+		auto randomValue = validChars[(esp_random() % validChars.length())];
+		returnValue += randomValue;
+	}
+
+	return returnValue;
 }

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -23,10 +23,11 @@ void WifiControl::begin(String essid, String password, String configured,
 	String _wifiConfigured = std::move(configured);
 	_wifiEssid = std::move(essid);
 	_wifiPassword = std::move(password);
-	 _wifiAPName = "ESP32_" + getHardwareMacAddress();
+	_wifiAPName = "ESP32_" + getHardwareMacAddress();
 
 	WiFi.onEvent(WiFiEvent);
 	if (_wifiConfigured == "True") {
+		operationMode_ = Mode::client;
 		DEBUG_PRINTLN("Wifi is configured");
 		DEBUG_PRINT("Connecting to ");
 		DEBUG_PRINTLN(_wifiEssid);
@@ -36,7 +37,7 @@ void WifiControl::begin(String essid, String password, String configured,
 		//WiFi.setAutoConnect ( true );
 		//WiFi.setAutoReconnect ( true );
 	} else {
-
+		operationMode_ = Mode::accessPoint;
 		DEBUG_PRINTLN("Wifi is NOT configured");
 		DEBUG_PRINTF("Starting Wifi AP '%s'", _wifiAPName);
 
@@ -50,6 +51,11 @@ void WifiControl::begin(String essid, String password, String configured,
 			WiFi.softAP(_wifiAPName.c_str());
 		}
 	}
+}
+
+WifiControl::Mode WifiControl::getOperationMode() const
+{
+	return operationMode_;
 }
 
 int WifiControl::status() {

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -123,7 +123,7 @@ String WifiControl::getSoftwareMacAddress(const String& delimiter)
 String WifiControl::generateRandomSecret(unsigned length) const
 {
 	// There is no "O" (Oh) to reduce confusion
-	const String validChars{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789.-,:!$/"};
+	const String validChars{"abcdefghjkmnopqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ23456789.-,:$/"};
 	String returnValue;
 
 	unsigned useLength = (length < minApSecretLength)?minApSecretLength:length;

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -125,9 +125,10 @@ String WifiControl::generateRandomSecret(unsigned length) const
 	// There is no "O" (Oh) to reduce confusion
 	const String validChars{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789.-,:!$/"};
 	String returnValue;
-	returnValue.reserve(length);
 
 	unsigned useLength = (length < minApSecretLength)?minApSecretLength:length;
+	returnValue.reserve(useLength);
+
 	for (unsigned i = 0; i < useLength; i++)
 	{
 		auto randomValue = validChars[(esp_random() % validChars.length())];

--- a/WifiControl.hpp
+++ b/WifiControl.hpp
@@ -13,9 +13,17 @@
 
 class WifiControl {
 	public:
+		enum class Mode {
+			unconfigured,
+			accessPoint,
+			client,
+		};
+
 		WifiControl(){};
 		bool connect();
 		bool disconnect();
+
+		Mode getOperationMode() const;
 
 		void begin(String essid, String password = "", String configured = "False",
 							 String hostname = "BasecampDevice", String apSecret="");
@@ -38,6 +46,8 @@ class WifiControl {
 		String _wifiPassword;
 		String _ap;
 		String _wifiAPName;
+
+		Mode operationMode_ = Mode::unconfigured;
 };
 
 #endif

--- a/WifiControl.hpp
+++ b/WifiControl.hpp
@@ -16,11 +16,15 @@ class WifiControl {
 		WifiControl(){};
 		bool connect();
 		bool disconnect();
-		void begin(String essid, String password = "", String configured = "False", String hostname = "BasecampDevice");
+
+		void begin(String essid, String password = "", String configured = "False",
+							 String hostname = "BasecampDevice", String apSecret="");
 		IPAddress getIP();
 		IPAddress getSoftAPIP();
 		int status();
 		static void WiFiEvent(WiFiEvent_t event);
+
+		String generateRandomSecret(unsigned length) const;
 
 		/*
 			Returns the MAC Address of the wifi adapter in hexadecimal form, optionally delimited

--- a/examples/doorsensor/doorsensor.ino
+++ b/examples/doorsensor/doorsensor.ino
@@ -32,7 +32,7 @@ void resetToFactoryDefaults()
     DEBUG_PRINTLN("Resetting to factory defaults");
     Configuration config(String{"/basecamp.json"});
     config.load();
-    config.reset();
+    config.resetExcept({ConfigurationKey::accessPointSecret, });
     config.save();  
 }
 

--- a/examples/doorsensor/doorsensor.ino
+++ b/examples/doorsensor/doorsensor.ino
@@ -33,7 +33,7 @@ void resetToFactoryDefaults()
     Configuration config(String{"/basecamp.json"});
     config.load();
     config.resetExcept({ConfigurationKey::accessPointSecret, });
-    config.save();  
+    config.save();
 }
 
 void setup() {
@@ -75,7 +75,7 @@ void setup() {
 //This function is called when the MQTT-Server is connected
 void onMqttConnect(bool sessionPresent) {
   DEBUG_PRINTLN(__func__);
-  
+
   //Subscribe to the delay topic
   iot.mqtt.subscribe(delaySleepTopic.c_str(), 0);
   //Trigger the transmission of the current state.
@@ -135,10 +135,10 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
 
 void suspendESP(uint16_t packetId) {
   DEBUG_PRINTLN(__func__);
-  
+
   //Check if the published package is the one of the door sensor
   if (packetId == statusPacketIdSub) {
-   
+
     if (delaySleep == true) {
       DEBUG_PRINTLN("Delaying Sleep");
       return;
@@ -151,6 +151,6 @@ void suspendESP(uint16_t packetId) {
   }
 }
 
-void loop() 
+void loop()
 {
 }


### PR DESCRIPTION
NOTE: This PR is based on https://github.com/merlinschumacher/Basecamp/pull/22 and only includes https://github.com/merlinschumacher/Basecamp/commit/04868ba2e5a77f6f60091a3982ef4d5a58d42231 additionally.

The web and dns servers do not need to be started in normal / productive mode because at the end, they won't work as the device is felt asleep after pins have been read out. Even if the final software, using the ESP, should not set the esp to deep sleep, it makes not too much sense to have the webserver running outside setup mode.