### PR TITLE
Add fixed access point secret override

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -17,7 +17,7 @@ namespace {
 
 Basecamp::Basecamp(SetupModeWifiEncryption setupModeWifiEncryption)
 	: configuration(String{"/basecamp.json"})
-	, setupModeWifiEncryption_(SetupModeWifiEncryption::none)
+	, setupModeWifiEncryption_(setupModeWifiEncryption)
 {
 }
 

--- a/Basecamp.hpp
+++ b/Basecamp.hpp
@@ -37,11 +37,20 @@ class Basecamp {
 			secured,	///< Use ESP32 default encryption (WPA2 at this time)
 		};
 
-		Basecamp(Basecamp::SetupModeWifiEncryption setupModeWifiEncryption = Basecamp::SetupModeWifiEncryption::none);
+		explicit Basecamp(Basecamp::SetupModeWifiEncryption setupModeWifiEncryption =
+			Basecamp::SetupModeWifiEncryption::none);
+
 		~Basecamp() = default;
+
 		Configuration configuration;
 		Preferences preferences;
-		bool begin();
+
+		/** Initialize.
+		 * Give a fixex ap secret here to override the one-time secret
+		 * password generation. If a password is given, the ctor given
+		 * SetupModeWifiEncryption will be overriden to SetupModeWifiEncryption::secure.
+		*/
+		bool begin(String fixedWiFiApEncryptionPassword = {});
 		void checkResetReason();
 		String showSystemInfo();
 		String hostname;

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -126,6 +126,11 @@ String WifiControl::getSoftwareMacAddress(const String& delimiter)
 	return format6Bytes(rawMac, delimiter);
 }
 
+unsigned WifiControl::getMinimumSecretLength() const
+{
+	return minApSecretLength;
+}
+
 String WifiControl::generateRandomSecret(unsigned length) const
 {
 	// There is no "O" (Oh) to reduce confusion

--- a/WifiControl.hpp
+++ b/WifiControl.hpp
@@ -32,6 +32,7 @@ class WifiControl {
 		int status();
 		static void WiFiEvent(WiFiEvent_t event);
 
+		unsigned getMinimumSecretLength() const;
 		String generateRandomSecret(unsigned length) const;
 
 		/*

--- a/examples/doorsensor/doorsensor.ino
+++ b/examples/doorsensor/doorsensor.ino
@@ -54,8 +54,10 @@ void setup() {
     resetToFactoryDefaults();
   }
 
-  //Initialize Basecamp
+  // Initialize Basecamp
   iot.begin();
+  // Alternate example: optional initialization with a fixed ap password for setup-mode:
+  // iot.begin("yoursecurepassword");
 
   if (resetPressed) {
     DEBUG_PRINTLN("**** CONFIG HAS BEEN MANUALLY RESET ****");


### PR DESCRIPTION
In regards to https://github.com/merlinschumacher/Basecamp/issues/14 - this enables a user to begin() with an optional access point secret override.