### PR TITLE
MQTT-Guard about outgoing packets

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -16,7 +16,8 @@ namespace {
 }
 
 Basecamp::Basecamp(SetupModeWifiEncryption setupModeWifiEncryption, ConfigurationUI configurationUi)
-	: configuration(String{"/basecamp.json"})
+	: MqttGuardInterface(mqtt)
+	, configuration(String{"/basecamp.json"})
 	, setupModeWifiEncryption_(setupModeWifiEncryption)
 	, configurationUi_(configurationUi)
 {

--- a/Basecamp.hpp
+++ b/Basecamp.hpp
@@ -25,13 +25,18 @@
 
 #ifndef BASECAMP_NOMQTT
 #include <AsyncMqttClient.h>
+#include "mqttGuardInterface.hpp"
 #endif
 
 #ifndef BASECAMP_NOOTA
 #include <ArduinoOTA.h>
 #endif
 
-class Basecamp {
+class Basecamp
+#ifndef BASECAMP_NOMQTT
+ : public MqttGuardInterface
+#endif
+{
 	public:
 		// How to handle encryption in setup mode (AP mode)
 		enum class SetupModeWifiEncryption

--- a/examples/doorsensor_guarded/doorsensor_guarded.ino
+++ b/examples/doorsensor_guarded/doorsensor_guarded.ino
@@ -1,0 +1,166 @@
+//Define DEBUG to get the Output from DEBUG_PRINTLN
+#define DEBUG 1
+
+#include <sstream>
+
+//Include Basecamp in this sketch
+#include <Basecamp.hpp>
+#include <Configuration.hpp>
+
+// Create a new Basecamp instance called iot that will start the ap in secure mode and the webserver ui only in setup mode
+Basecamp iot{Basecamp::SetupModeWifiEncryption::secured, Basecamp::ConfigurationUI::accessPoint};
+// Uncomment the following line and comment to one above to start the ESP with open wifi and always running config ui
+// Basecamp iot;
+
+//Variables for the sensor and the battery
+static const int ResetPin = 35;
+static const int SensorPin = 32;
+static const int BatteryPin = 34;
+int sensorValue = 0;
+//The batteryLimit defines the point at which the battery is considered empty.
+int batteryLimit = 3300;
+
+//This is used to control if the ESP should enter sleep mode or not
+bool delaySleep = false;
+
+//Variables for the mqtt packages and topics
+uint16_t statusPacketIdSub = 0;
+String delaySleepTopic;
+String statusTopic;
+String batteryTopic;
+String batteryValueTopic;
+
+// Reset the configuration to factory defaults (all empty)
+void resetToFactoryDefaults()
+{
+    DEBUG_PRINTLN("Resetting to factory defaults");
+    Configuration config(String{"/basecamp.json"});
+    config.load();
+    config.resetExcept({ConfigurationKey::accessPointSecret, });
+    config.save();
+}
+
+void setup() {
+  //configuration of the battery and sensor pins
+  pinMode(ResetPin, INPUT_PULLDOWN);
+  pinMode(SensorPin, INPUT_PULLDOWN);
+  pinMode(BatteryPin, INPUT);
+
+  //read the status of the doorsensor as soon as possible to determine the state that triggered it
+  sensorValue = digitalRead(SensorPin);
+
+  bool resetPressed = (digitalRead(ResetPin) == HIGH);
+  if (resetPressed)
+  {
+    resetToFactoryDefaults();
+  }
+
+  // Initialize Basecamp
+  iot.begin();
+  // Alternate example: optional initialization with a fixed ap password for setup-mode:
+  // iot.begin("yoursecurepassword");
+
+  if (resetPressed) {
+    DEBUG_PRINTLN("**** CONFIG HAS BEEN MANUALLY RESET ****");
+  }
+
+  //Configure the MQTT topics
+  delaySleepTopic = "cmd/" + iot.hostname + "/delaysleep";
+  statusTopic = "stat/" + iot.hostname + "/status";
+  batteryTopic = "stat/" + iot.hostname + "/battery";
+  batteryValueTopic = "stat/" + iot.hostname + "/batteryvalue";
+
+  //Set up the Callbacks for the MQTT instance. Refer to the Async MQTT Client documentation
+  // TODO: We should do this actually _before_ connecting the mqtt client...
+  iot.mqtt.onConnect(onMqttConnect);
+  iot.mqttOnPublish(suspendESP);
+  iot.mqtt.onMessage(onMqttMessage);
+}
+
+
+//This function is called when the MQTT-Server is connected
+void onMqttConnect(bool sessionPresent) {
+  DEBUG_PRINTLN(__func__);
+
+  //Subscribe to the delay topic
+  iot.mqtt.subscribe(delaySleepTopic.c_str(), 0);
+  //Trigger the transmission of the current state.
+  transmitStatus();
+}
+
+
+//This function transfers the state of the sensor. That includes the door status, battery status and level
+void transmitStatus() {
+  DEBUG_PRINTLN(__func__);
+
+  if (sensorValue == 0) {
+    DEBUG_PRINTLN("Door open");
+    //Transfer the current state of the sensor to the MQTT broker
+    statusPacketIdSub = iot.mqttPublish(statusTopic.c_str(), 1, true, "open" );
+    //Configure the wakeup pin to wake if the door is closed
+    esp_sleep_enable_ext0_wakeup((gpio_num_t)SensorPin, 1);
+  } else {
+    DEBUG_PRINTLN("Door closed");
+    //Transfer the current state of the sensor to the MQTT broker
+    statusPacketIdSub = iot.mqttPublish(statusTopic.c_str(), 1, true, "closed" );
+    //Configure the wakeup pin to wake if the door is closed
+    esp_sleep_enable_ext0_wakeup((gpio_num_t)SensorPin, 0);
+  }
+
+  //Read the current analog battery value
+  sensorValue = analogRead(BatteryPin);
+  //sensorC stores the battery value as a char
+  char sensorC[6];
+  //convert the sensor value to a string
+  sprintf(sensorC, "%04i", sensorValue);
+  //Send the sensor value to the MQTT broker
+  iot.mqttPublish(batteryValueTopic.c_str(), 1, true, sensorC);
+  //Check the battery level and publish the state
+  if (sensorValue < batteryLimit) {
+    DEBUG_PRINTLN("Battery empty");
+    iot.mqttPublish(batteryTopic.c_str(), 1, true, "empty" );
+  } else {
+    DEBUG_PRINTLN("Battery full");
+    iot.mqttPublish(batteryTopic.c_str(), 1, true, "full" );
+  }
+  DEBUG_PRINTLN("Data published");
+}
+
+//This topic is called if an MQTT message is received
+void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
+  DEBUG_PRINTLN(__func__);
+
+  //Check if the payload eqals "true" and set delaySleep correspondigly
+  //Since we only subscribed to one topic, we only have to compare the payload
+  if (strcmp(payload, "true") == 0)  {
+    delaySleep = true;
+  } else  {
+    delaySleep = false;
+  }
+}
+
+void suspendESP(uint16_t packetId) {
+  DEBUG_PRINTLN(__func__);
+
+  if (delaySleep) {
+      DEBUG_PRINTLN("Delaying Sleep for manual keep-alive request");
+      return;
+  }
+
+  if (!iot.mqttAllSent()) {
+      std::ostringstream debug;
+      debug << "Waiting for " << iot.mqttRemainingPackets() << " mqtt packets to be sent before going to sleep.";
+      DEBUG_PRINTLN(debug.str().c_str());
+      return;
+  }
+
+  DEBUG_PRINTLN("Entering deep sleep");
+  //properly disconnect from the MQTT broker
+  iot.mqtt.disconnect();
+  //send the ESP into deep sleep
+  esp_deep_sleep_start();
+}
+
+void loop()
+{
+}

--- a/log.hpp
+++ b/log.hpp
@@ -1,0 +1,35 @@
+#ifndef BASECAMP_LOG_HPP
+#define BASECAMP_LOG_HPP
+
+#include <functional>
+#include <string>
+#include <map>
+
+// Header-Only definition of log functionality for reuse.
+namespace basecampLog
+{
+    /// Severity of log messages.
+    enum class Severity
+    {
+        trace,
+        debug,
+        info,
+        warning,
+        error,
+        fatal,
+    };
+
+    const std::map<Severity, std::string> SeverityText {
+        {Severity::trace, "TRACE"},
+        {Severity::debug, "DEBUG"},
+        {Severity::info, "INFO"},
+        {Severity::warning, "WARNING"},
+        {Severity::error, "ERROR"},
+        {Severity::fatal, "FATAL"},
+    };
+
+    /// Definition of a generic log callback.
+    using LogCallback = std::function<void(basecampLog::Severity severity, const std::string& message)>;
+}
+
+#endif //  BASECAMP_LOG_HPP

--- a/mqttGuard.cpp
+++ b/mqttGuard.cpp
@@ -1,0 +1,85 @@
+#include "mqttGuard.hpp"
+
+#include <algorithm>
+#include <sstream>
+
+MqttGuard::MqttGuard(basecampLog::LogCallback logCallback)
+    : logCallback_(std::move(logCallback))
+{
+}
+
+void MqttGuard::registerPacket(IdType packetId)
+{
+    if (!isValidPacketId(packetId)) {
+        tryLog(basecampLog::Severity::info, "Not registering invlaid MQTT-packet.", packetId);
+        return;
+    }
+
+    packets_.emplace_back(packetId);
+}
+
+void MqttGuard::unregisterPacket(IdType packetId)
+{
+    auto found = std::find(packets_.begin(), packets_.end(), packetId);
+
+    if (found == packets_.end()) {
+        tryLog(basecampLog::Severity::info, "Not unregistering unknown MQTT-packet.", packetId);
+        return;
+    }
+
+    packets_.erase(found);
+}
+
+size_t MqttGuard::remainingPacketCount() const
+{
+    return packets_.size();
+}
+
+bool MqttGuard::allSent() const
+{
+    return (remainingPacketCount() == 0);
+}
+
+bool MqttGuard::isValidPacketId(IdType packetId) const
+{
+    // Generally invalid packet id
+    if (packetId == 0)
+    {
+        return false;
+    }
+
+    // Do not allow duplicates
+    if (std::find(packets_.begin(), packets_.end(), packetId) != packets_.end())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void MqttGuard::reset()
+{
+    tryLog(basecampLog::Severity::warning, "MqttGuard has been manually reset.");
+
+    packets_.clear();
+}
+
+void MqttGuard::tryLog(basecampLog::Severity severity, const std::string &message)
+{
+    if (!logCallback_) {
+        return;
+    }
+
+    logCallback_(severity, message);
+}
+
+void MqttGuard::tryLog(basecampLog::Severity severity, const std::string &message, IdType packetId)
+{
+    if (!logCallback_) {
+        return;
+    }
+
+    std::ostringstream text;
+    text << message << " - Packet-ID: " << packetId;
+    logCallback_(severity, text.str());
+}

--- a/mqttGuard.cpp
+++ b/mqttGuard.cpp
@@ -11,7 +11,7 @@ MqttGuard::MqttGuard(basecampLog::LogCallback logCallback)
 void MqttGuard::registerPacket(IdType packetId)
 {
     if (!isValidPacketId(packetId)) {
-        tryLog(basecampLog::Severity::info, "Not registering invlaid MQTT-packet.", packetId);
+        tryLog(basecampLog::Severity::info, "Not registering invalid MQTT-packet.", packetId);
         return;
     }
 

--- a/mqttGuard.hpp
+++ b/mqttGuard.hpp
@@ -8,8 +8,8 @@
 
 /**
   Helper to guard outgoing mqtt packets.
-  On packet sending, register the packets within this class and
-  pull the empty() function to see if everything has been sent completely.
+  On packet sending, register the packets within this class, unregister them within the onPublish and
+  pull the allSent() function to see if everything has been sent completely.
 */
 class MqttGuard
 {

--- a/mqttGuard.hpp
+++ b/mqttGuard.hpp
@@ -1,0 +1,70 @@
+#ifndef BASECAMP_MQTT_GUARD_HPP
+#define BASECAMP_MQTT_GUARD_HPP
+
+#include "log.hpp"
+
+#include <functional>
+#include <vector>
+
+/**
+  Helper to guard outgoing mqtt packets.
+  On packet sending, register the packets within this class and
+  pull the empty() function to see if everything has been sent completely.
+*/
+class MqttGuard
+{
+public:
+    /// Typesafety forward of AsyncMqttClients packet_id type
+    using IdType = uint16_t;
+
+    /**
+        Construct a new guard.
+        @param LogCallback Optional log callback.
+     */
+    explicit MqttGuard(basecampLog::LogCallback logCallback = {});
+    ~MqttGuard() = default;
+
+    /**
+        Register a new packet that is going to sent by mqtt.
+        @param packetId Packet-ID returned by AsyncMqttClient::publish()
+     */
+    void registerPacket(IdType packetId);
+
+    /**
+        Unregister a packet after it has been sent successfully.
+        @param packetId Packet-ID returned by AsyncMqttClient::onPublish()
+     */
+    void unregisterPacket(IdType packetId);
+
+    /// Returns the amount of packets waiting to be sent.
+    size_t remainingPacketCount() const;
+
+    /// Returns true if all packets have been sent.
+    bool allSent() const;
+
+    /**
+        Reset to empty state (force).
+        Maybe necessary if getting disconnected.
+     */
+    void reset();
+private:
+    /**
+        Check a packetId for validity.
+        @param packetId Packet-ID to be checked.
+        @return True if the packetId can be safely added.
+     */
+    bool isValidPacketId(IdType packetId) const;
+
+    /// Try to log message if logCallback_ has been set in ctor.
+    void tryLog(basecampLog::Severity severity, const std::string& message);
+
+    /// Try to log message with packetId if logCallback_ has been set in ctor.
+    void tryLog(basecampLog::Severity severity, const std::string& message, IdType packetId);
+
+    /// Optional callback for log-messages
+    basecampLog::LogCallback logCallback_;
+    /// List of all remaining packets
+    std::vector<IdType> packets_;
+};
+
+#endif // #define BASECAMP_MQTT_GUARD_HPP

--- a/mqttGuardInterface.cpp
+++ b/mqttGuardInterface.cpp
@@ -1,0 +1,52 @@
+#include "MqttGuardInterface.hpp"
+
+MqttGuardInterface::MqttGuardInterface(AsyncMqttClient& mqttClient)
+    : mqttClient_(mqttClient)
+    , mqttGuard_(std::make_shared<MqttGuard>())
+{
+    // Default callbacks in case the user does not set one so internally everything is kept fine.
+    mqttOnDisconnect([](AsyncMqttClientDisconnectReason /*reason*/){});
+    mqttOnPublish([](uint16_t /*packetId*/) {});
+}
+
+uint16_t MqttGuardInterface::mqttPublish(const char* topic, uint8_t qos, bool retain,
+        const char* payload, size_t length, bool dup, uint16_t message_id)
+{
+    mqttGuard_->registerPacket(mqttClient_.publish(topic, qos, retain, payload, length, dup, message_id));
+}
+
+AsyncMqttClient& MqttGuardInterface::mqttOnPublish(AsyncMqttClientInternals::OnPublishUserCallback callback)
+{
+    // Intercept the onPublish and make sure that mqttGuard is held alive until the callback is fired.
+    auto mqttGuard = mqttGuard_;
+    return mqttClient_.onPublish([mqttGuard, callback](uint16_t packetId){
+        mqttGuard->unregisterPacket(packetId);
+        if (callback) {
+            callback(packetId);
+        }
+    });
+}
+
+AsyncMqttClient& MqttGuardInterface::mqttOnDisconnect(AsyncMqttClientInternals::OnDisconnectUserCallback callback)
+{
+    // Intercept the onDisconnect and make sure that mqttGuard is held alive until the callback is fired.
+    auto mqttGuard = mqttGuard_;
+    return mqttClient_.onDisconnect([mqttGuard, callback]
+                            (AsyncMqttClientDisconnectReason reason){
+        // Make sure that disconnet respects that there could be no more packets be sent.
+        mqttGuard->reset();
+        if (callback) {
+            callback(reason);
+        }
+    });
+}
+
+bool MqttGuardInterface::mqttAllSent() const
+{
+    return mqttGuard_->allSent();
+}
+
+size_t MqttGuardInterface::mqttRemainingPackets() const
+{
+    return mqttGuard_->remainingPacketCount();
+}

--- a/mqttGuardInterface.hpp
+++ b/mqttGuardInterface.hpp
@@ -1,0 +1,43 @@
+#ifndef BASECAMP_MQTT_GUARD_INTERFACE_HPP
+#define BASECAMP_MQTT_GUARD_INTERFACE_HPP
+
+#include "mqttGuard.hpp"
+
+#include <memory>
+
+#include <AsyncMqttClient.h>
+
+/**
+    Class to interface between AsyncMqttClient and MqttGuard.
+    Intercepts outgoing messages and incoming publish acknowledgements to keep track of packets to be sent.
+
+    Use mqttOnPublish instead of mqtt.OnPublish()
+    Use consequently mqttOnDisconnect instead of mqtt.OnDisconnect()
+    Use mqttPublish instead of mqtt.publish()
+
+    Use then mqttAllSent() to check if there are remaining packets to be sent.
+
+    Its up to the owner of this class to keep mqttClient valid in the lifetime of an instance of this class.
+ */
+class MqttGuardInterface
+{
+public:
+    explicit MqttGuardInterface(AsyncMqttClient& mqttClient);
+
+    AsyncMqttClient& mqttOnPublish(AsyncMqttClientInternals::OnPublishUserCallback callback);
+    AsyncMqttClient& mqttOnDisconnect(AsyncMqttClientInternals::OnDisconnectUserCallback callback);    
+
+    uint16_t mqttPublish(const char* topic, uint8_t qos, bool retain, const char* payload = nullptr, size_t length = 0, bool dup = false, uint16_t message_id = 0);
+
+    /// Returns true if all mqtt-packets have been sent.
+    bool mqttAllSent() const;
+
+    /// Returns the remaining to-be-transmitted packet count.
+    size_t mqttRemainingPackets() const;
+
+private:
+    AsyncMqttClient& mqttClient_;
+    std::shared_ptr<MqttGuard> mqttGuard_;
+};
+
+#endif // BASECAMP_MQTT_GUARD_INTERFACE_HPP


### PR DESCRIPTION
Added a MqttGuard Class and corresponding interface to Basecamp so anyone can check if all mqtt-packets have been sent easily before going to put the esp to deep sleep.

Does not break with old projects.
For documentation, see added example and mqttGuardInterface.hpp

Old projects can be easily upgraded by doing the following modifications:
- change every Basecamp::mqtt.onPublish to Basecamp::mqttOnPublish
- change every Basecamp::mqtt.onDisconnect to Basecamp::mqttOnDisconnect
- change every Basecamp::mqtt.publish to Basecamp::mqttPublish
- check Basecamp::mqttAllSent() to see if its safe to sleep.