### PR TITLE
Get the properties of the setup WiFi AP

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -50,6 +50,27 @@ String Basecamp::_cleanHostname()
 };
 
 /**
+ * Returns true if a secret for the setup WiFi AP is set
+ */
+bool Basecamp::isSetupModeWifiEncrypted(){
+	return (setupModeWifiEncryption_ == SetupModeWifiEncryption::secured);
+}
+
+/**
+ * Returns the SSID of the setup WiFi network
+ */
+String Basecamp::getSetupModeWifiName(){
+	return "ESP32_" + wifi.getHardwareMacAddress();
+}
+
+/**
+ * Returns the secret of the setup WiFi network
+ */
+String Basecamp::getSetupModeWifiSecret(){
+	return configuration.get(ConfigurationKey::accessPointSecret);
+}
+
+/**
  * This is the initialisation function for the Basecamp class.
  */
 bool Basecamp::begin(String fixedWiFiApEncryptionPassword)
@@ -67,7 +88,7 @@ bool Basecamp::begin(String fixedWiFiApEncryptionPassword)
 	Serial.begin(115200);
 	// Display a simple lifesign
 	Serial.println("");
-	Serial.println("Basecamp V.0.1.6");
+	Serial.println("Basecamp V.0.1.8");
 
 	// Load configuration from internal flash storage.
 	// If configuration.load() fails, reset the configuration

--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -60,7 +60,7 @@ bool Basecamp::isSetupModeWifiEncrypted(){
  * Returns the SSID of the setup WiFi network
  */
 String Basecamp::getSetupModeWifiName(){
-	return "ESP32_" + wifi.getHardwareMacAddress();
+	return wifi.getAPName();
 }
 
 /**

--- a/Basecamp.hpp
+++ b/Basecamp.hpp
@@ -64,6 +64,9 @@ class Basecamp {
 		bool begin(String fixedWiFiApEncryptionPassword = {});
 		void checkResetReason();
 		String showSystemInfo();
+		bool isSetupModeWifiEncrypted();
+		String getSetupModeWifiName();
+		String getSetupModeWifiSecret();
 		String hostname;
 		struct taskParms {
 			const char* parm1;

--- a/WifiControl.cpp
+++ b/WifiControl.cpp
@@ -65,6 +65,10 @@ IPAddress WifiControl::getSoftAPIP() {
 	return WiFi.softAPIP();
 }
 
+String WifiControl::getAPName() {
+	return _wifiAPName;
+}
+
 void WifiControl::WiFiEvent(WiFiEvent_t event)
 {
 	Preferences preferences;

--- a/WifiControl.hpp
+++ b/WifiControl.hpp
@@ -32,6 +32,7 @@ class WifiControl {
 							 String hostname = "BasecampDevice", String apSecret="");
 		IPAddress getIP();
 		IPAddress getSoftAPIP();
+		String getAPName();
 		int status();
 		static void WiFiEvent(WiFiEvent_t event);
 


### PR DESCRIPTION
This PR introduces three new functions for easier handling of the setup WiFi network:

* `bool isSetupModeWifiEncrypted()`: Returns true if the WiFi is encrypted
* `String getSetupModeWifiName()`: Returns the SSID of the setup WiFi (ESP32_<MAC>)
* `String getSetupModeWifiSecret()`: Returns the secret of the setupt WiFi

This PR is required to fix https://github.com/jamct/DoorsignEPD/issues/19
