### PR TITLE
Connection problems with Broker/multiple tcp-connections

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -291,7 +291,7 @@ void Basecamp::DnsHandling(void * dnsServerPointer)
 		while(1) {
 			// handle each request
 			dnsServer->processNextRequest();
-			vTaskDelay(100);
+			vTaskDelay(1000);
 		}
 };
 #endif


### PR DESCRIPTION
The vTaskDealy parameter "100" seems to force Basecamp to open multiple tcp-connections on start-up. This causes connection issues with a MQTT-Broker. I tested the issue with the parameter "1000" and it seems that this solves the problem.

Wireshark sample - Client 192.168.1.116, Broker 192.168.1.119
![wireshark keine verbindung mqtt](https://user-images.githubusercontent.com/25673638/38729922-e891d400-3f14-11e8-9451-b6a64adcd28f.jpg)

![wireshark verbindung mqtt](https://user-images.githubusercontent.com/25673638/38729923-e8acdbe2-3f14-11e8-9cde-760b2e860444.jpg)
