### PR TITLE
Reusable webserver

### DIFF
--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -192,7 +192,11 @@ bool Basecamp::begin(String fixedWiFiApEncryptionPassword)
 	if (shouldEnableConfigWebserver())
 	{
 		// Start webserver and pass the configuration object to it
-		web.begin(configuration);
+		// Also pass a Lambda-function that restarts the device after the configuration has been saved.
+		web.begin(configuration, [](){
+			delay(2000);
+			esp_restart();
+		});
 		// Add a webinterface element for the h1 that contains the device name. It is a child of the #wrapper-element.
 		web.addInterfaceElement("heading", "h1", "","#wrapper");
 		web.setInterfaceElementAttribute("heading", "class", "fat-border");

--- a/Basecamp.cpp
+++ b/Basecamp.cpp
@@ -191,12 +191,6 @@ bool Basecamp::begin(String fixedWiFiApEncryptionPassword)
 #ifndef BASECAMP_NOWEB
 	if (shouldEnableConfigWebserver())
 	{
-		// Start webserver and pass the configuration object to it
-		// Also pass a Lambda-function that restarts the device after the configuration has been saved.
-		web.begin(configuration, [](){
-			delay(2000);
-			esp_restart();
-		});
 		// Add a webinterface element for the h1 that contains the device name. It is a child of the #wrapper-element.
 		web.addInterfaceElement("heading", "h1", "","#wrapper");
 		web.setInterfaceElementAttribute("heading", "class", "fat-border");
@@ -260,6 +254,12 @@ bool Basecamp::begin(String fixedWiFiApEncryptionPassword)
 		}
 		#endif
 		#endif
+		// Start webserver and pass the configuration object to it
+		// Also pass a Lambda-function that restarts the device after the configuration has been saved.
+		web.begin(configuration, [](){
+			delay(2000);
+			esp_restart();
+		});
 	}
 	#endif
 	Serial.println(showSystemInfo());

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -5,13 +5,36 @@
    */
 #include "Configuration.hpp"
 
-Configuration::Configuration(String filename)
-	: _jsonFile(std::move(filename))
+Configuration::Configuration()
+	: _memOnlyConfig( true ),
+	_jsonFile()
 {
+}
+
+Configuration::Configuration(String filename)
+	: _memOnlyConfig( false ),
+	_jsonFile(std::move(filename))
+{
+}
+
+void Configuration::setMemOnly() {
+	_memOnlyConfig = true;
+	_jsonFile = "";
+}
+
+void Configuration::setFileName(const String& filename) {
+	_memOnlyConfig = false;
+	_jsonFile = filename;
 }
 
 bool Configuration::load() {
 	DEBUG_PRINTLN("Loading config file ");
+	
+	if (_memOnlyConfig) {
+		DEBUG_PRINTLN("Memory-only configuration: Nothing loaded!");
+		return false;
+	}
+	
 	DEBUG_PRINTLN(_jsonFile);
 	if (!SPIFFS.begin(true)) {
 		Serial.println("Could not access SPIFFS.");
@@ -43,6 +66,11 @@ bool Configuration::load() {
 
 bool Configuration::save() {
 	DEBUG_PRINTLN("Saving config file");
+	
+	if (_memOnlyConfig) {
+		DEBUG_PRINTLN("Memory-only configuration: Nothing saved!");
+		return false;
+	}
 
 	File configFile = SPIFFS.open(_jsonFile, "w");
 	if (!configFile) {

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -36,13 +36,25 @@ static const String getKeyName(ConfigurationKey key)
 
 class Configuration {
 	public:
+		// Default constructor: Memory-only configuration (NO EEPROM read/writes
+		Configuration();
+		// Constructor with filename: Can be read from and written to EEPROM
 		explicit Configuration(String filename);
 		~Configuration() = default;
+		
+		// Switched configuration to memory-only and empties filename
+		void setMemOnly();
+		// Sets new filename and removes memory-only tag
+		void setFileName(const String& filename);
+		// Returns memory-only state of configuration
+		bool isMemOnly() {return _memOnlyConfig;}
 
 		const String& getKey(ConfigurationKey configKey) const;
 
+		// Both functions return true on successful load or save. Return false on any failure. Also return false for memory-only configurations.
 		bool load();
 		bool save();
+		
 		void dump();
 
 		// Returns true if the key 'key' exists
@@ -87,6 +99,8 @@ class Configuration {
 		String _jsonFile;
 		bool _configurationTainted = false;
 		String noResult_ = {};
+		// Set to true if configuration is memory-only
+		bool _memOnlyConfig;
 };
 
 #endif

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -28,8 +28,7 @@ WebServer::WebServer()
 
 void WebServer::begin(Configuration &configuration) {
 	SPIFFS.begin();
-	server.begin();
-
+	
 	server.on("/" , HTTP_GET, [](AsyncWebServerRequest * request)
 	{
 			AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", index_htm_gz, index_htm_gz_len);
@@ -133,6 +132,8 @@ void WebServer::begin(Configuration &configuration) {
 #endif
 			request->send(404);
 	});
+	
+	server.begin();
 }
 
 void WebServer::debugPrintRequest(AsyncWebServerRequest *request)

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -26,7 +26,7 @@ WebServer::WebServer()
 #endif
 }
 
-void WebServer::begin(Configuration &configuration) {
+void WebServer::begin(Configuration &configuration, std::function<void()> submitFunc) {
 	SPIFFS.begin();
 	
 	server.on("/" , HTTP_GET, [](AsyncWebServerRequest * request)
@@ -98,7 +98,7 @@ void WebServer::begin(Configuration &configuration) {
 			request->send(response);
 	});
 
-	server.on("/submitconfig", HTTP_POST, [&configuration, this](AsyncWebServerRequest *request)
+	server.on("/submitconfig", HTTP_POST, [&configuration, submitFunc, this](AsyncWebServerRequest *request)
 	{
 			if (request->params() == 0) {
 				DEBUG_PRINTLN("Refusing to take over an empty configuration submission.");
@@ -119,9 +119,8 @@ void WebServer::begin(Configuration &configuration) {
 			configuration.save();
 			request->send(201);
 
-			// Why? What is this magic value for?
-			delay(2000);
-			esp_restart();
+			// Only call submitFunc when it has been set to something useful
+			if( submitFunc ) submitFunc();
 	});
 
 	server.onNotFound([this](AsyncWebServerRequest *request)
@@ -207,4 +206,17 @@ void WebServer::setInterfaceElementAttribute(const String &id, const String &key
 			return;
 		}
 	}
+}
+
+void WebServer::reset() {
+	interfaceElements.clear();
+	// We should also reset the server itself, according to documentation, but it will cause a crash.
+	// It works without reset, if you only configure one server after a reboot. Not sure what happens if you want to reconfigure during runtime.
+	//server.reset();
+	//server.addHandler(&events);
+//#ifdef BASECAMP_USEDNS
+//#ifdef DNSServer_h
+	//server.addHandler(new CaptiveRequestHandler()).setFilter(ON_AP_FILTER);
+//#endif
+//#endif
 }

--- a/WebServer.hpp
+++ b/WebServer.hpp
@@ -30,12 +30,18 @@ class WebServer {
 		WebServer();
 		~WebServer() = default;
 
-		void begin(Configuration &configuration);
+		void begin(Configuration &configuration, std::function<void()> submitFunc = 0);
 		bool addURL(const char* url, const char* content, const char* mimetype);
+		
+		// Remark: The server should be stopped before any changes to the interface elements are done to avoid inconsistent results if a request comes in at that very moment.
+		// However, ESPAsyncWebServer does not support any kind of end() function or something like that in the moment.
 		void addInterfaceElement(const String &id, String element, String content, String parent = "#configform", String configvariable = "");
 
 		// Sets "key" to "value" in element with id "id" if exists.
 		void setInterfaceElementAttribute(const String &id, const String &key, String value);
+		
+		// Removes all interface elements
+		void reset();
 
 		struct cmp_str
 		{


### PR DESCRIPTION
Hey

Quite similar to the idea discussed in [Issue 35](https://github.com/merlinschumacher/Basecamp/issues/35), I want to use the webserver to display and set values that are used to control sensors and actuators.

Turned out the code was nearly, but not quite there yet.
In detail, the only real problem was the hard-coded reboot when the webserver recieved a new configuration. Good for setting WiFi passwords, bad for controlling actuators.
So I modified the webserver to not perform a hard-coded rebott and instead optionally execute an external function when a configuration is recieved. Basecamp uses this function to perform said reboot, so everything should be backwards compatible.

To remove the non-needed fields from the webserver, I added a reset() function to the webserver. But I currently think it does not work properly, because the AsyncWebServer would need to be reset at well. But unfortunately that crashes, so there seems to be a bug somewhere in the AsyncWebServer.
Anyway, it still can be used as intended: When Wifi is not configured, the default webserver should be started to configure WiFi. When WiFi has been configure and the device has been rebooted, the default webserver should not be started, so there is nothing to be reset and the modified interface can be used by the user.

By default this would lead to frequent reads and writes to the EEPROM for configuration values that are not actually supposed to be kept across reboots. So I also extended the Configuration class to support a memory-only operation mode, where no EEPROM reads and writes are performed.

Example usage for all that can be found here: [WifiBlinds](https://github.com/theWaldschrat/WifiBlinds)

Additionally I noticed that according to the documentation the webserver should first be configured and then started by calling begin(), not the other way around. So I changed that as well.

Cheers,
Holger