### PR TITLE
 Added basic support for wired connections using eth phys

### DIFF
--- a/Basecamp.hpp
+++ b/Basecamp.hpp
@@ -15,6 +15,10 @@
 #include "WifiControl.hpp"
 #endif
 
+#ifndef BASECAMP_NOETH
+#include "EthControl.hpp"
+#endif
+
 #ifndef BASECAMP_NOWEB
 #ifdef BASECAMP_USEDNS
 #include <DNSServer.h>
@@ -80,6 +84,11 @@ class Basecamp
 #ifndef BASECAMP_NOWIFI
 		String mac;
 		WifiControl wifi;
+#endif
+
+#ifndef BASECAMP_NOETH
+		String macEth;
+		EthControl eth;
 #endif
 
 #ifndef BASECAMP_NOMQTT

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -18,6 +18,7 @@
 // TODO: Extend with all known keys
 enum class ConfigurationKey {
 	accessPointSecret,
+	ethConfigured,
 };
 
 // TODO: Extend with all known keys
@@ -29,6 +30,9 @@ static const String getKeyName(ConfigurationKey key)
 	{
 		case ConfigurationKey::accessPointSecret:
 			return "APSecret";
+			break;
+		case ConfigurationKey::ethConfigured:
+			return "EthConfigured";
 			break;
 	}
 	return "";

--- a/EthControl.cpp
+++ b/EthControl.cpp
@@ -1,0 +1,65 @@
+#include "EthControl.hpp"
+
+
+void EthControl::begin(String hostname) {
+    ETH.begin();
+    ETH.setHostname(hostname.c_str());
+    WiFi.onEvent(WiFiEvent);
+}
+
+bool EthControl::config(const String& ip, const String& gateway, const String& subnet, const String& dns1, const String& dns2 ) {
+    IPAddress mip, mgateway, msubnet, mdns1, mdns2; 
+    mip.fromString(ip);
+    mgateway.fromString(gateway);
+    msubnet.fromString(subnet);
+    mdns1.fromString(dns1);
+    mdns2.fromString(dns2);
+
+    return config(mip, mgateway, msubnet, mdns1, mdns1);
+}
+
+
+bool EthControl::config(IPAddress ip, IPAddress gateway, IPAddress subnet, IPAddress dns1, IPAddress dns2 )
+{
+    return ETH.config(ip, gateway, subnet, dns1, dns2);
+}
+
+
+IPAddress EthControl::getIP() {
+    return ETH.localIP();
+}
+
+String EthControl::getMac() {
+    return ETH.macAddress();
+}
+
+void EthControl::WiFiEvent(WiFiEvent_t event){
+    switch (event) {
+        case SYSTEM_EVENT_ETH_START:
+            DEBUG_PRINTLN("ETH Started");
+            break;
+        case SYSTEM_EVENT_ETH_CONNECTED:
+            DEBUG_PRINTLN("ETH Connected");
+            break;
+        case SYSTEM_EVENT_ETH_GOT_IP:
+            DEBUG_PRINT("ETH MAC: ");
+            DEBUG_PRINT(ETH.macAddress());
+            DEBUG_PRINT(", IPv4: ");
+            DEBUG_PRINT(ETH.localIP());
+            if (ETH.fullDuplex()) {
+                DEBUG_PRINT(", FULL_DUPLEX");
+            }
+            DEBUG_PRINT(", ");
+            DEBUG_PRINT(ETH.linkSpeed());
+            DEBUG_PRINTLN("Mbps");
+            break;
+        case SYSTEM_EVENT_ETH_DISCONNECTED:
+            DEBUG_PRINTLN("ETH Disconnected");
+            break;
+        case SYSTEM_EVENT_ETH_STOP:
+            DEBUG_PRINTLN("ETH Stopped");
+            break;
+        default:
+            break;
+    }
+}

--- a/EthControl.hpp
+++ b/EthControl.hpp
@@ -1,0 +1,39 @@
+#ifndef EthControl_h
+#define EthControl_h
+
+// CONFIG FOR WAVESHARE LAN8720 WITH POWER EN MOD BY SAUTTER
+//#define ETH_CLK_MODE    ETH_CLOCK_GPIO0_IN
+//#define ETH_POWER_PIN   17
+//#define ETH_TYPE        ETH_PHY_LAN8720
+//#define ETH_ADDR        1
+//#define ETH_MDC_PIN     23
+//#define ETH_MDIO_PIN    18
+
+#include "debug.hpp"
+#include <iomanip>
+#include <sstream>
+#include <ETH.h>
+#include <WiFiClient.h>
+#include <Preferences.h>
+#include <IPAddress.h>
+
+
+
+class EthControl {
+	public:
+        EthControl(){};
+                
+        void begin(String hostname = "BasecampDevice");
+        bool config(IPAddress ip, IPAddress gateway, IPAddress subnet, IPAddress dns1, IPAddress dns2 );
+        bool config(const String& ip, const String& gateway, const String& subnet, const String& dns1, const String& dns2 );
+
+        IPAddress getIP();
+        String getMac();
+        
+
+        static void WiFiEvent(WiFiEvent_t event);
+    private:
+
+};
+
+#endif //EthControl_h


### PR DESCRIPTION
wire your ESP32 to a phy for example like shown here: 
https://sautter.com/blog/ethernet-on-esp32-using-lan8720/
and add the matching defines (example for this hardware in EthControl.h)
Then basecamp is able to aquire an ip via dhcp or a fixed one can be set in the config